### PR TITLE
Source webhook secret from environment

### DIFF
--- a/metaworkflow/charts/metaworkflow/templates/deployment.yaml
+++ b/metaworkflow/charts/metaworkflow/templates/deployment.yaml
@@ -33,6 +33,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "true"
+            - name: WEBHOOK_SECRET
+              value: {{ .Values.webhook.secret }}
           ports:
             - name: http
               containerPort: 8080

--- a/metaworkflow/charts/metaworkflow/values.yaml
+++ b/metaworkflow/charts/metaworkflow/values.yaml
@@ -14,6 +14,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+webhook:
+  secret: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/metaworkflow/main.py
+++ b/metaworkflow/main.py
@@ -105,7 +105,7 @@ def extract_master_info(payload):
   
 
 def validate_github_webhook_secret(request):
-  digest_maker = hmac.new("a-secret-key".encode("utf-8"), bytearray(request.data), hashlib.sha1)
+  digest_maker = hmac.new(os.environ["WEBHOOK_SECRET"].encode("utf-8"), bytearray(request.data), hashlib.sha1)
   if not hmac.compare_digest(digest_maker.hexdigest(), request.headers.get('X-Hub-Signature').replace("sha1=", "")):
     print("Invalid X-Hub-Signature in Github webhook call")
     return False


### PR DESCRIPTION
Replaced the hardcoded fake webhook secret value with one sourced
from the environment variable WEBHOOK_SECRET

Set PYTHONUNBUFFERED to true to avoid delays logging to stdout